### PR TITLE
DEV-1692 Added ACTIONS_RUNTIME_TOKEN to the ci pipeline action for trivy for magical reasons

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -75,7 +75,7 @@ jobs:
           tags: ${{ env.LATEST_TAG }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: 'gombocai/cli:latest'
           format: 'table'

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -47,13 +47,15 @@ jobs:
           tags: ${{ env.TEST_TAG }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: ${{ env.TEST_TAG }}
           format: 'table'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+        env:
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}          
 
       - name: run structure tests
         uses: plexsystems/container-structure-test-action@v0.1.0
@@ -82,7 +84,6 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
-        env:
-          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
     
               

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -56,6 +56,8 @@ jobs:
           severity: 'CRITICAL,HIGH'
         env:
           ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
 
       - name: run structure tests
         uses: plexsystems/container-structure-test-action@v0.1.0
@@ -86,6 +88,8 @@ jobs:
           severity: 'CRITICAL,HIGH'
         env:
           ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
         
     
               

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -77,19 +77,6 @@ jobs:
         with:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ env.LATEST_TAG }}
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          image-ref: 'gombocai/cli:latest'
-          format: 'table'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-        env:
-          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TRIVY_SKIP_DB_UPDATE: true
-          TRIVY_SKIP_JAVA_DB_UPDATE: true
         
     
               

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -55,7 +55,7 @@ jobs:
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
         env:
-          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}          
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: run structure tests
         uses: plexsystems/container-structure-test-action@v0.1.0
@@ -84,6 +84,8 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+        env:
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
     
               

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -74,12 +74,15 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ env.LATEST_TAG }}
 
-
-
-
-
-
-
-
-
-          
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: 'gombocai/cli:latest'
+          format: 'table'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+        env:
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+              

--- a/.github/workflows/trivy_db_update.yml
+++ b/.github/workflows/trivy_db_update.yml
@@ -1,0 +1,39 @@
+# Note: This workflow only updates the cache. You should create a separate workflow for your actual Trivy scans.
+# In your scan workflow, set TRIVY_SKIP_DB_UPDATE=true and TRIVY_SKIP_JAVA_DB_UPDATE=true.
+name: Update Trivy Cache
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run daily at midnight UTC
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  update-trivy-db:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup oras
+        uses: oras-project/setup-oras@v1
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Download and extract the vulnerability DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/db
+          oras pull ghcr.io/aquasecurity/trivy-db:2
+          tar -xzf db.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/db
+          rm db.tar.gz
+
+      - name: Download and extract the Java DB
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/.cache/trivy/java-db
+          oras pull ghcr.io/aquasecurity/trivy-java-db:1
+          tar -xzf javadb.tar.gz -C $GITHUB_WORKSPACE/.cache/trivy/java-db
+          rm javadb.tar.gz
+
+      - name: Cache DBs
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: cache-trivy-${{ steps.date.outputs.date }}


### PR DESCRIPTION

# Description

The trivy vulnerability scan tends to hit rate limiting issues which cause our build to fail. There are magical reasons that the rate limiting issue goes away described here - https://github.com/aquasecurity/trivy-action/issues/389. 

Using the instructions in the trivy docs here - https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#updating-caches-in-the-default-branch - we can update the trivy cache daily and then use that cache when executing the trivy scans.

# Validation

If this build succeeds on the first try then the issue is likely resolved.

# Checklist

- [ ] I have performed manual testing to verify behavior of this PR and included evidence above
- [ ] Another person has reviewed, understood, and tested this work
